### PR TITLE
docs: add warmup documentation and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to the Aviant Speech Enhancement Server are documented here.
+
+## [0.4.4] - 2026-04-06
+
+### Added
+- GPU shader warmup (`--warmup`, `--warmup-only`) to eliminate cold start latency on first request
+- Pre-warmed Docker image workflow for scale-to-zero deployments
+- `scripts/warmup-image.sh` convenience script for building warmed images
+
+## [0.4.3] - 2026-04-05
+
+### Added
+- `/v1/normalize` endpoint for standalone loudness normalization and resampling (no GPU required)
+- Vulkan adapter logging at startup for GPU diagnostics
+
+## [0.4.2] - 2026-03-20
+
+### Added
+- ARM64 container image support
+
+## [0.4.1] - 2026-03-19
+
+### Added
+- Lark v1 model support (`--model lark-v1`)
+- S3 and Azure Blob Storage support for async enhancement (`s3://`, `az://` URLs)
+- Docker image version tagging
+
+### Fixed
+- CPU backend (NdArray) now works correctly
+
+## [0.3.0] - 2026-03-12
+
+### Added
+- Initial release with Lark v2 and Finch v2 models
+- WGPU (Vulkan) GPU backend
+- `/v1/enhance` and `/v1/enhance/async` endpoints
+- SDK key authentication and usage telemetry
+- Float16 weights and inference

--- a/README.md
+++ b/README.md
@@ -74,6 +74,31 @@ curl -X POST http://localhost:8080/v1/enhance \
   -o enhanced.wav
 ```
 
+### `POST /v1/normalize`
+
+Normalize an audio file without enhancement. Applies EBU R128 loudness normalization (-17 LUFS) and resamples to 32 kHz mono. Returns `audio/wav`. This is the same preprocessing that runs internally before enhancement, useful when you need the normalized audio separately.
+
+Does not use the GPU or run model inference, so responses are fast (roughly 2-4 seconds per minute of audio).
+
+**File upload** (multipart/form-data):
+
+```bash
+curl -X POST http://localhost:8080/v1/normalize \
+  -H "Authorization: Bearer $SDK_KEY" \
+  -F audio=@input.wav \
+  -o normalized.wav
+```
+
+**URL mode** (application/json):
+
+```bash
+curl -X POST http://localhost:8080/v1/normalize \
+  -H "Authorization: Bearer $SDK_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com/audio.wav"}' \
+  -o normalized.wav
+```
+
 ### `POST /v1/enhance/async`
 
 Async enhancement via cloud storage. The server downloads from `input_url`, processes the audio, and uploads the result to `output_url`. A preprocessed (normalized, 32 kHz) copy of the input is also uploaded alongside the output as `{input_filename}_preprocessed.wav`.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Lark v2 | 20s | < 4 GB | ~4.7 s |
 Lark v1 | 20s | < 3 GB | ~2.3 s |
 Finch v1 | 20s | < 3 GB | ~2.3 s |
 
-> **Note:** The first request after startup is slow (up to ~80 s on an RTX 3090) due to Vulkan shader optimization. All subsequent requests run at full speed.
+> **Note:** The first request after startup is slow (up to ~80 s on an RTX 3090) due to Vulkan shader compilation. Use `--warmup` or build a pre-warmed image to eliminate this. See [Reducing cold start](#reducing-cold-start) below.
 
 ## API reference
 
@@ -143,6 +143,55 @@ When both are provided, the header takes precedence. Create SDK keys in the [ai-
 | `--model` | Model: `lark-v2`, `lark-v1`, `finch` | `lark-v2` |
 | `--batch-size` | Frames processed in parallel on the GPU | unlimited |
 | `--weights` | Path to a custom `.aviant` weight file | auto per model setting |
+| `--warmup` | Run a dummy inference at startup to compile GPU shaders before serving | off |
+| `--no-warmup` | Disable startup warmup (the default) | — |
+| `--warmup-only` | Run warmup then exit. Used for building pre-warmed images | — |
+
+## Reducing cold start
+
+The first inference after startup takes 45-80 s because the GPU shaders are compiled on demand. There are two ways to handle this:
+
+### Option 1: Startup warmup
+
+Add `--warmup` to run a dummy inference during server startup. This compiles all GPU shaders before the server accepts traffic. The container takes longer to start, but user requests are always fast.
+
+```bash
+docker run --gpus all -p 8080:8080 \
+  -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \
+  -e SDK_KEY="YOUR-KEY" \
+  ghcr.io/ai-coustics/aviant-wgpu:latest --batch-size 1 --model lark-v2 --warmup
+```
+
+### Option 2: Pre-warmed Docker image
+
+Build a new image that bakes in the compiled shader cache. This eliminates the cold start on subsequent container boots, which is useful for scale-to-zero deployments where containers restart frequently.
+
+**Important:** Shaders are specialized per batch size. The warmup must use the same `--batch-size` as production inference.
+
+```bash
+# 1. Run warmup on a GPU host (compiles shaders, writes driver caches to disk)
+docker run --gpus all \
+  -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \
+  --name aviant-warmup \
+  ghcr.io/ai-coustics/aviant-wgpu:latest \
+  --model lark-v2 --batch-size 1 --warmup-only
+
+# 2. Commit the stopped container as a new image
+docker commit aviant-warmup aviant-wgpu-warmed
+docker rm aviant-warmup
+
+# 3. Use the warmed image in production
+docker run --gpus all -p 8080:8080 \
+  -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \
+  -e SDK_KEY="YOUR-KEY" \
+  aviant-wgpu-warmed --batch-size 1 --model lark-v2
+```
+
+A convenience script is available in the [SDK repository](https://github.com/ai-coustics/aviant-sdk/blob/main/scripts/warmup-image.sh):
+
+```bash
+./scripts/warmup-image.sh --base ghcr.io/ai-coustics/aviant-wgpu:latest --model lark-v2 --batch-size 1
+```
 
 ## Input and output
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ docker run --gpus all -p 8080:8080 \
   aviant-wgpu-warmed --batch-size 1 --model lark-v2
 ```
 
-A convenience script is available in the [SDK repository](https://github.com/ai-coustics/aviant-sdk/blob/main/scripts/warmup-image.sh):
+A convenience script is provided at [`scripts/warmup-image.sh`](scripts/warmup-image.sh):
 
 ```bash
 ./scripts/warmup-image.sh --base ghcr.io/ai-coustics/aviant-wgpu:latest --model lark-v2 --batch-size 1

--- a/scripts/warmup-image.sh
+++ b/scripts/warmup-image.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Build a warmed-up container image by running GPU shader compilation once
+# and committing the result. Shaders are specialized per batch size, so
+# the warmup must use the same --batch-size as production inference.
+#
+# Usage:
+#   ./scripts/warmup-image.sh [--base IMAGE] [--model MODEL] [--batch-size N] [--tag TAG]
+#
+# Examples:
+#   ./scripts/warmup-image.sh --batch-size 1
+#   ./scripts/warmup-image.sh --base ghcr.io/ai-coustics/aviant-wgpu:0.4.4 --model finch --batch-size 2
+#   ./scripts/warmup-image.sh --tag my-registry/aviant-warmed:latest --batch-size 1
+
+set -euo pipefail
+
+BASE_IMAGE="ghcr.io/ai-coustics/aviant-wgpu:latest"
+MODEL="lark-v2"
+BATCH_SIZE="1"
+TAG="aviant-wgpu-warmed"
+CONTAINER_NAME="aviant-warmup-$$"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base)       BASE_IMAGE="$2"; shift 2 ;;
+        --model)      MODEL="$2"; shift 2 ;;
+        --batch-size) BATCH_SIZE="$2"; shift 2 ;;
+        --tag)        TAG="$2"; shift 2 ;;
+        *)            echo "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+echo "=== Warmup Image Builder ==="
+echo "Base:       $BASE_IMAGE"
+echo "Model:      $MODEL"
+echo "Batch size: $BATCH_SIZE"
+echo "Tag:        $TAG"
+echo ""
+
+# Step 1: Run warmup with GPU access
+echo "Step 1: Running warmup (this triggers GPU shader compilation)..."
+docker run --gpus all \
+    -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \
+    -e __GL_SHADER_DISK_CACHE=1 \
+    -e __GL_SHADER_DISK_CACHE_PATH=/cache/nvidia \
+    -e __GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1 \
+    --name "$CONTAINER_NAME" \
+    "$BASE_IMAGE" \
+    --model "$MODEL" --batch-size "$BATCH_SIZE" --warmup-only
+
+echo ""
+
+# Step 2: Inspect what files were written during warmup
+echo "Step 2: Inspecting cached files..."
+docker diff "$CONTAINER_NAME" | head -50 || true
+echo ""
+
+# Step 3: Commit as new image
+echo "Step 3: Committing warmed container as $TAG..."
+docker commit "$CONTAINER_NAME" "$TAG"
+docker rm "$CONTAINER_NAME"
+
+echo ""
+echo "Done! Test the warmed image (use the same --batch-size for inference):"
+echo ""
+echo "  # Warmed image:"
+echo "  docker run --gpus all -p 8080:8080 \\"
+echo "    -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \\"
+echo "    $TAG --model $MODEL --batch-size $BATCH_SIZE"
+echo ""
+echo "  # Compare with cold image:"
+echo "  docker run --gpus all -p 8080:8080 \\"
+echo "    -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \\"
+echo "    $BASE_IMAGE --model $MODEL --batch-size $BATCH_SIZE"


### PR DESCRIPTION
## Summary

Documents the GPU shader warmup feature added in ai-coustics/aviant-sdk#9, and creates a changelog backfilled from recent releases.

### Changes

- **Reducing cold start** section in README with two approaches:
  - `--warmup` flag for startup shader compilation
  - Pre-warmed Docker image workflow (`--warmup-only` + `docker commit`)
- **Server options** table updated with `--warmup`, `--no-warmup`, `--warmup-only` flags
- **Cold start note** updated to reference the new section instead of just saying "it's slow"
- **CHANGELOG.md** created and backfilled from v0.3.0 through v0.4.4

Addresses #2

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify CHANGELOG dates and versions match release tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2