### PR TITLE
docs: document 0.5.0 and 0.5.1 (macOS guidance, /health, doctor, upgrade notes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to the Aviant Speech Enhancement Server are documented here.
 
+## [0.5.1] - 2026-08-17
+
+### Added
+- macOS (Apple Silicon) guidance: run the server natively, not in a container. No container runtime on macOS can reach the Apple GPU, so the Docker image resolves to an arm64 CPU build that runs roughly 14x slower — slower than realtime
+- Documented how a client container reaches a natively-run server on the same Mac (`host.docker.internal` on Docker Desktop, `host.orb.internal` on OrbStack), verified end-to-end
+
+### Changed
+- Corrected the cold-start figures. Shader compilation measures 75–120 s on Apple Silicon (Metal) and ~80 s on an RTX 3090 (Vulkan); the previous "45–80 s" understated it. Warmup results are cached on disk relative to the process's working directory, which is why a pre-warmed image removes the cost on later container boots
+
+## [0.5.0] - 2026-08-17
+
+Reliability and security release. Several changes can stop a **running deployment from restarting** — read the upgrade notes below first.
+
+### Added
+- `aviant doctor` subcommand: checks ffmpeg and its filters, the weight file, the licence key (offline), temp-directory writability, GPU adapters, and whether a real tensor operation on the selected device returns the right answer. Reports every problem in one pass and exits non-zero if the machine cannot serve. `--json` for scripts and support tickets
+- `GET /health` reports real readiness instead of a constant: `200` while the server can serve, `503` with a `reason` once it cannot. The payload adds the selected backend, which backends the image was built with, ffmpeg capabilities and inference queue depth
+- `--host` to control the bind address
+- `--allow-env-key BOOL` to control whether requests with no `Authorization` header are served using the server's own `SDK_KEY`
+- `--allow-cpu-fallback` to start on the CPU backend when the GPU cannot compute, instead of refusing to start
+- `--help` and `--version`
+- Startup warning when the CPU backend runs on aarch64 in a container, naming the native path as the fix
+
+### Changed
+- **`--host` now defaults to `127.0.0.1`** instead of `0.0.0.0`. The published Docker images pass `--host 0.0.0.0` in their entrypoint and are unaffected
+- Startup fails if ffmpeg is incomplete. `ffmpeg`, `ffprobe`, `loudnorm`, `deesser` and the `pcm_s16le` encoder are verified before serving, and every missing capability is named at once. `libmp3lame` remains optional
+- Startup fails if the GPU cannot compute, verified with a real tensor operation rather than adapter enumeration
+- On device loss the server answers the in-flight request, flips `/health` to `503`, and exits `70` so a supervisor restarts it. **Run with a restart policy** (`--restart unless-stopped`, or a Kubernetes liveness probe)
+- Upload file extensions are checked against an allowlist; an unrecognised extension gets `400` with the allowed list. Common audio and video containers are accepted in any case
+- Invalid command-line arguments exit `2`, and an unknown `--backend` value is rejected at parse time
+- A busy port, a privileged port or a bad `--host` produce a clear message naming the cause and the fix, instead of a panic
+
+### Fixed
+- `/health` no longer reports `ok` after the model thread has died — the case where an orchestrator kept a container in service while every request failed
+- Audio that cannot be decoded returns `400` instead of `500`, so an orchestrator does not retry a request that can never succeed. `/v1/enhance` and `/v1/normalize` classify it the same way
+- A malformed `Authorization` header (`Basic ...`, a bare token, or `Bearer` with no key) is rejected with `401` instead of silently falling back to the server's own `SDK_KEY`
+- An invalid `input_url` extension on `/v1/enhance/async` is rejected with `400` before the `202`, rather than failing invisibly in the background. Extensionless object keys are accepted
+
+### Upgrade notes
+
+1. **Binding.** A native install that relied on remote access is loopback-only until it passes `--host 0.0.0.0`. The shipped images already do
+2. **ffmpeg.** A deployment limping along with a partial ffmpeg will refuse to start and name what is missing
+3. **GPU.** A host whose GPU cannot compute will refuse to start. Pass `--allow-cpu-fallback` (roughly 14x slower) or `--backend cpu` to choose it deliberately
+4. **Restart policy.** `503` now means the process is exiting to be restarted. Without a restart policy it stays down
+
+Run `aviant doctor` on the target host before upgrading.
+
 ## [0.4.5] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,22 +2,26 @@
 
 Aviant is a self-hosted speech enhancement server by [ai-coustics](https://ai-coustics.com). It takes noisy audio and produces clean, enhanced speech — running entirely on your infrastructure.
 
+> **On a Mac, do not use Docker.** No container runtime on macOS can reach the Apple GPU, so the image below resolves to an arm64 CPU build that runs roughly **14x slower** — slower than realtime. See [Running on macOS](#running-on-macos).
+
 ## Quick start
 
 **1. Run the server** (requires an NVIDIA GPU):
 
 ```bash
-docker run --gpus all -p 8080:8080 \
+docker run --gpus all -p 8080:8080 --restart unless-stopped \
   -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \
   -e SDK_KEY="YOUR-KEY" \
   ghcr.io/ai-coustics/aviant-wgpu:latest --batch-size 1 --model lark-v2
 ```
 
+`--restart unless-stopped` matters: if the compute device is lost, the server reports `503` and exits so a supervisor can replace it. Without a restart policy it stays down.
+
 **2. Check it's running:**
 
 ```bash
 curl http://localhost:8080/health
-# {"status":"ok"}
+# {"status":"ok", ...}
 ```
 
 **3. Enhance an audio file:**
@@ -59,13 +63,40 @@ Lark v2 | 20s | < 4 GB | ~4.7 s |
 Lark v1 | 20s | < 3 GB | ~2.3 s |
 Finch v1 | 20s | < 3 GB | ~2.3 s |
 
-> **Note:** The first request after startup is slow (up to ~80 s on an RTX 3090) due to Vulkan shader compilation. Use `--warmup` or build a pre-warmed image to eliminate this. See [Reducing cold start](#reducing-cold-start) below.
+> **Note:** The first request after startup is slow (~80 s on an RTX 3090) due to Vulkan shader compilation. Use `--warmup` or build a pre-warmed image to eliminate this. See [Reducing cold start](#reducing-cold-start) below.
 
 ## API reference
 
 ### `GET /health`
 
-Returns `{"status":"ok"}` when the server is ready.
+`200` with `"status":"ok"` when the server can serve; `503` with `"status":"unavailable"` and a `reason` when it cannot. Use it as both a liveness and a readiness probe — a `503` means restart, not retry.
+
+```json
+{
+  "status": "ok",
+  "version": "0.5.1",
+  "model": "lark-v2",
+  "backend": {
+    "selected": "wgpu",
+    "status": {"cpu": "compiled", "wgpu": "selected", "cuda": "not-compiled"}
+  },
+  "ffmpeg": {"ffmpeg": true, "ffprobe": true, "loudnorm": true, "deesser": true, "libmp3lame": true},
+  "queue": {"depth": 0, "capacity": 16}
+}
+```
+
+`not-compiled` means this image was built without that backend, which is different from a backend that is present but has no usable device.
+
+### `aviant doctor`
+
+Checks the environment and reports *every* problem in one run, then exits non-zero if the machine could not serve. Run it on a host before deploying, or when opening a support ticket.
+
+```bash
+docker run --rm ghcr.io/ai-coustics/aviant-wgpu:latest doctor
+docker run --rm ghcr.io/ai-coustics/aviant-wgpu:latest doctor --json
+```
+
+It verifies ffmpeg and its required filters, the weight file, the licence key (offline, without printing it), temp-directory writability, the GPU adapters, and that a real tensor operation on the selected device returns the right answer.
 
 ### `POST /v1/enhance`
 
@@ -134,11 +165,14 @@ curl -X POST http://localhost:8080/v1/enhance/async \
 
 ### Error codes
 
-| Status | Meaning |
-|---|---|
-| `400` | Bad request — invalid audio format or missing parameters |
-| `401` | Unauthorized — missing or invalid SDK key |
-| `500` | Internal server error — processing failed |
+| Status | Meaning | Retry? |
+|---|---|---|
+| `400` | Bad request — an unsupported upload file extension, or audio that cannot be decoded | No, it will fail identically |
+| `401` | Unauthorized — missing, malformed or invalid SDK key | No |
+| `500` | Internal server error — processing failed | Maybe |
+| `503` | The server cannot serve at all — the compute device was lost, or a required ffmpeg capability is missing | After the restart |
+
+On `503` the process exits so your supervisor restarts it.
 
 ## Authentication
 
@@ -151,22 +185,69 @@ Pass your SDK key in one of two ways:
 
 When both are provided, the header takes precedence. Create SDK keys in the [ai-coustics developer portal](https://developers.ai-coustics.com).
 
+> **`SDK_KEY` serves unauthenticated requests.** With `SDK_KEY` set, a request that carries *no* `Authorization` header is served using it — so anything that can reach the port can spend your licence. For any deployment reachable beyond loopback, set `--allow-env-key false` and have clients send their own header. This default will change in a future major version.
+
+A malformed header (`Basic ...`, a bare token, or `Bearer` with no key) is rejected with `401` rather than falling back to `SDK_KEY`.
+
 ## Server options
+
+Run `--help` for the authoritative list.
 
 | Flag | Description | Default |
 |---|---|---|
+| `--host` | Address to bind | `127.0.0.1` |
 | `--port` | Port the server listens on | `8080` |
 | `--backend` | Compute backend: `wgpu`, `cuda`, `cpu` | `wgpu` |
 | `--model` | Model: `lark-v2`, `lark-v1`, `finch` | `lark-v2` |
 | `--batch-size` | Frames processed in parallel on the GPU | unlimited |
 | `--weights` | Path to a custom `.aviant` weight file | auto per model setting |
+| `--allow-env-key` | Serve requests with no `Authorization` header using the server's own `SDK_KEY` | `true` |
+| `--allow-cpu-fallback` | Fall back to the CPU backend if the GPU cannot compute, instead of refusing to start | off |
 | `--warmup` | Run a dummy inference at startup to compile GPU shaders before serving | off |
 | `--no-warmup` | Disable startup warmup (the default) | — |
 | `--warmup-only` | Run warmup then exit. Used for building pre-warmed images | — |
 
+**`--host` defaults to loopback.** A server started by hand serves only the machine it runs on. The published Docker images pass `--host 0.0.0.0` in their entrypoint — a container binding loopback would be unreachable through `-p` — so containers are unaffected.
+
+### Startup checks
+
+The server verifies before it accepts traffic, and refuses to start rather than failing every request later:
+
+- **ffmpeg**: `ffmpeg`, `ffprobe`, `loudnorm`, `deesser` and the `pcm_s16le` encoder must be present. Every missing capability is named at once. `libmp3lame` is optional
+- **The compute device**: a real tensor operation must return the right answer on the selected backend. Pass `--allow-cpu-fallback` to fall back to the CPU (roughly 14x slower) instead
+
+## Running on macOS
+
+macOS runs the server **natively**, not in a container. Docker Desktop, Podman, Colima, OrbStack and Apple's `container` tool all run Linux in a VM, and Apple exposes no GPU compute API to VMs — so a container on a Mac cannot reach Metal at any layer, and falls back to a CPU build measured at roughly 14x slower.
+
+> **Development target. Not supported for production deployment.** Apple GPU compute cannot be tested in CI, so we do not promise support for something we cannot verify on every change.
+
+Measured on an M4 Max, lark-v2, `--batch-size 1`, 30.6 s of audio:
+
+| Backend | End-to-end wall | vs realtime |
+|---|---|---|
+| wgpu (Metal) | **21.2 s** | 0.69x — faster than realtime |
+| cpu (NdArray) | 288.8 s | 9.4x — far slower than realtime |
+
+Native macOS packaging (`brew install`) is not released yet. If you need to run Aviant on a Mac today, [get in touch](#support) — do not use the Docker image as a substitute.
+
+### Reaching a native server from your containers
+
+The server binds `127.0.0.1` by default. Docker Desktop and OrbStack both proxy host loopback, so a client container reaches it without widening the bind:
+
+```yaml
+services:
+  your-client:
+    environment:
+      # Docker Desktop; use host.orb.internal on OrbStack
+      AVIANT_URL: http://host.docker.internal:8080
+```
+
+Do **not** pass `--host 0.0.0.0` for this. It is not needed on either runtime, and combined with the default `--allow-env-key` it lets anything on your network spend your licence.
+
 ## Reducing cold start
 
-The first inference after startup is slow because GPU kernels are compiled on demand (45-80 s for WGPU/Vulkan, longer for CUDA/NVRTC). There are two ways to handle this:
+The first inference after startup is slow because GPU kernels are compiled on demand: ~80 s for WGPU/Vulkan on an RTX 3090, 75–120 s for WGPU/Metal on an M4 Max, and longer for CUDA/NVRTC. There are two ways to handle this:
 
 ### Option 1: Startup warmup
 
@@ -246,8 +327,9 @@ docker run --gpus all -p 8080:8080 \
 
 ## Limitations
 
-- Processing very long files (1 h @ 32 kHz mono, ~230 MB) may exhaust memory
+- Processing very long files (1 h @ 32 kHz mono, ~230 MB) may exhaust host memory. `--batch-size` does not control this: the pipeline computes the STFT for every frame before batching begins, so host memory scales with the *length of the input*. Split inputs longer than ~10 minutes
 - Processing many small files concurrently may exhaust disk I/O (file-based pipeline)
+- The inference queue holds 16 requests; beyond that, requests wait. Watch `queue.depth` in `/health`
 - The server authenticates and sends usage telemetry to the ai-coustics backend. Contact us to discuss air-gapped deployments
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl -X POST http://localhost:8080/v1/enhance \
 For environments without Vulkan drivers (e.g. Azure NC/ND-series VMs), use the CUDA image instead:
 
 ```bash
-docker run --gpus all -p 8080:8080 \
+docker run --gpus all -p 8080:8080 --restart unless-stopped \
   -e SDK_KEY="YOUR-KEY" \
   ghcr.io/ai-coustics/aviant-cuda:latest --batch-size 1 --model lark-v2
 ```
@@ -91,12 +91,24 @@ Finch v1 | 20s | < 3 GB | ~2.3 s |
 
 Checks the environment and reports *every* problem in one run, then exits non-zero if the machine could not serve. Run it on a host before deploying, or when opening a support ticket.
 
+Give it the **same** GPU access, ICD mount and key as the server, or it will report failures caused by the way you invoked the diagnostic rather than by the host:
+
 ```bash
-docker run --rm ghcr.io/ai-coustics/aviant-wgpu:latest doctor
-docker run --rm ghcr.io/ai-coustics/aviant-wgpu:latest doctor --json
+# WGPU image
+docker run --rm --gpus all \
+  -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \
+  -e SDK_KEY="YOUR-KEY" \
+  ghcr.io/ai-coustics/aviant-wgpu:latest doctor
+
+# CUDA image (no ICD mount), machine-readable for a support ticket
+docker run --rm --gpus all \
+  -e SDK_KEY="YOUR-KEY" \
+  ghcr.io/ai-coustics/aviant-cuda:latest doctor --json
 ```
 
 It verifies ffmpeg and its required filters, the weight file, the licence key (offline, without printing it), temp-directory writability, the GPU adapters, and that a real tensor operation on the selected device returns the right answer.
+
+Because it runs a real tensor operation, dropping `--gpus all` or the ICD mount makes the GPU checks fail on a perfectly healthy host. Omitting `SDK_KEY` is only a warning — the licence check is skipped, every other check still runs.
 
 ### `POST /v1/enhance`
 
@@ -254,7 +266,7 @@ The first inference after startup is slow because GPU kernels are compiled on de
 Add `--warmup` to run a dummy inference during server startup. This compiles all GPU shaders before the server accepts traffic. The container takes longer to start, but user requests are always fast.
 
 ```bash
-docker run --gpus all -p 8080:8080 \
+docker run --gpus all -p 8080:8080 --restart unless-stopped \
   -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \
   -e SDK_KEY="YOUR-KEY" \
   ghcr.io/ai-coustics/aviant-wgpu:latest --batch-size 1 --model lark-v2 --warmup
@@ -273,13 +285,15 @@ docker run --gpus all \
   --name aviant-warmup \
   ghcr.io/ai-coustics/aviant-wgpu:latest \
   --model lark-v2 --batch-size 1 --warmup-only
+# No --restart here: --warmup-only is meant to exit, and a restart policy
+# would relaunch it forever. Restart policies belong on serving containers.
 
 # 2. Commit the stopped container as a new image
 docker commit aviant-warmup aviant-wgpu-warmed
 docker rm aviant-warmup
 
 # 3. Use the warmed image in production
-docker run --gpus all -p 8080:8080 \
+docker run --gpus all -p 8080:8080 --restart unless-stopped \
   -v /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro \
   -e SDK_KEY="YOUR-KEY" \
   aviant-wgpu-warmed --batch-size 1 --model lark-v2
@@ -311,7 +325,7 @@ Azure NC/ND-series VMs have NVIDIA GPUs with CUDA but typically no Vulkan driver
 4. Run the CUDA image:
 
 ```bash
-docker run --gpus all -p 8080:8080 \
+docker run --gpus all -p 8080:8080 --restart unless-stopped \
   -e SDK_KEY="YOUR-KEY" \
   ghcr.io/ai-coustics/aviant-cuda:latest --warmup --batch-size 1 --model lark-v2
 ```


### PR DESCRIPTION
## Summary

The public docs stopped at **0.4.5**. 0.5.0 shipped without a changelog entry, so
the release that changes *how a deployment restarts* is currently undocumented for
customers. This adds 0.5.0 and 0.5.1 and brings the README in line.

Companion to `ai-coustics/aviant-sdk#50`.

## 0.5.0 — reliability and security

Four changes can stop a **running deployment from restarting**, so the entry leads
with that and carries explicit upgrade notes:

1. `--host` now defaults to `127.0.0.1`. The shipped images pass `--host 0.0.0.0`
   in their entrypoint and are unaffected; a native install that relied on remote
   access is loopback-only until it passes the flag.
2. Startup fails if ffmpeg is incomplete — `ffmpeg`, `ffprobe`, `loudnorm`,
   `deesser`, `pcm_s16le`. A deployment limping along on a partial ffmpeg will
   refuse to start and name what is missing.
3. Startup fails if the GPU cannot compute, verified with a real tensor operation.
4. On device loss the server exits `70` for a supervisor to restart. **Without a
   restart policy it stays down.**

README follows the behaviour: `/health` gets its real readiness semantics and
documented payload instead of a constant `ok`, `503` joins the error table,
`doctor` is documented, and the `SDK_KEY`-serves-unauthenticated-requests exposure
is stated plainly next to `--allow-env-key` instead of left implicit.

## 0.5.1 — macOS

The headline is that **Docker is the wrong answer on a Mac**. No container runtime
on macOS can reach the Apple GPU, so the image resolves to an arm64 CPU build
measured at roughly **14x slower — slower than realtime**. That was undocumented,
and the Quick Start led Mac users straight into it. There is now a callout at the
top and a "Running on macOS" section.

Also documents the host-loopback bridge for customers running client containers
against a native server (`host.docker.internal` / `host.orb.internal`), verified
end-to-end on Docker Desktop 28.1.1.

## Corrections

- **Cold start** said 45–80 s. Measured: ~80 s for Vulkan on an RTX 3090, and
  75–120 s for Metal on an M4 Max.
- **The long-file memory limit** now states the real mechanism: the pipeline
  computes the STFT for every frame before batching begins, so host memory scales
  with the *length of the input* and `--batch-size` does not control it. The old
  wording implied batch size was the lever.
- Quick Start gains `--restart unless-stopped`, which 0.5.0's exit-on-device-loss
  behaviour depends on.

## Review notes

The redaction scan flags 6 MEDIUM findings, all false positives:
`host.docker.internal` and `host.orb.internal` are Docker's and OrbStack's
documented public hostnames (matched by the `*.internal` rule), and the rest are
`http://localhost:8080/...` API examples the README has always carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
